### PR TITLE
Update test script in DeployTypeDoc workflow

### DIFF
--- a/.github/workflows/DeployTypeDoc.yml
+++ b/.github/workflows/DeployTypeDoc.yml
@@ -26,7 +26,7 @@ jobs:
 
             - name: Run Tests and Generate Coverage
               run: |
-                  npm run test:verbose || echo "Ignoring test failures"
+                  npm run test:coverage || echo "Ignoring test failures"
 
             - name: Run TypeDoc
               run: npx typedoc


### PR DESCRIPTION
Modified the GitHub Actions DeployTypeDoc workflow to run `npm run test:coverage` instead of `npm run test:verbose`. This change switches from verbose test output to generating test coverage, aiming to improve code quality insights during deployment.