### PR TITLE
Update coverage URL to relative path

### DIFF
--- a/scripts/fix-coverage-paths.cjs
+++ b/scripts/fix-coverage-paths.cjs
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const coverageDir = path.join(__dirname, '..', '.locale', 'coverage');
-const typedocUrl = 'https://pxammaxp.github.io/TSinjex/';
+const typedocUrl = '../../';
 
 const getAllFiles = (dir, files = []) => {
     fs.readdirSync(dir).forEach(file => {


### PR DESCRIPTION
Changed the coverage URL from an absolute web link to a relative file path to ensure compatibility with local file system references. This facilitates easier navigation and access to the coverage reports in different environments.