### PR TITLE
Disable console errors and enhance docs generation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,7 +53,7 @@
         "no-prototype-builtins": "off",
         "@typescript-eslint/no-empty-function": "off",
         "deprecation/deprecation": "warn",
-        "no-console": "error",
+        "no-console": "off",
         "@typescript-eslint/naming-convention": [
             "warn",
             {

--- a/.github/workflows/DeployTypeDoc.yml
+++ b/.github/workflows/DeployTypeDoc.yml
@@ -24,12 +24,8 @@ jobs:
             - name: Install Dependencies
               run: npm install
 
-            - name: Run Tests and Generate Coverage
-              run: |
-                  npm run test:coverage || echo "Ignoring test failures"
-
-            - name: Run TypeDoc
-              run: npx typedoc
+            - name: Run TypeDoc Generation (TypeDoc, Test Coverage, fixes and badges)
+              run: npm run docs:generate
 
             - name: Deploy to GitHub Pages
               env:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
-### Project Time
-
 ![Time](https://waka.mpassarello.de/api/badge/MaxP/interval:any/project:TSinjex?label=Project%20time)
 
-### Test Coverage
-
-[Coverage Report..](https://pxammaxp.github.io/TSinjex/coverage/lcov-report/index.html)
-
-| Statements                  | Branches                | Functions                 | Lines             |
-| --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-statements.svg) | ![Branches](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-branches.svg) | ![Functions](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-functions.svg) | ![Lines](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-lines.svg) |
-
+[![Statements](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-statements.svg) ![Branches](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-branches.svg) ![Functions](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-functions.svg) ![Lines](https://pxammaxp.github.io/TSinjex/coverage/badges/badge-lines.svg) ](https://pxammaxp.github.io/TSinjex/coverage/lcov-report/index.html)
 
 # TSinjex
 

--- a/package.json
+++ b/package.json
@@ -6,14 +6,21 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
+    "build": "npm run build:tsc",
     "build:tsc": "tsc",
     "lint": "eslint --ext .ts .",
     "lint:fix": "eslint --fix --ext .ts .",
+    "test": "jest",
     "test:file": "jest --watch --onlyChanged --coverage=true --verbose",
     "test:verbose": "jest --verbose",
-    "test:coverage": "jest --config jest.config.coverage.cjs --coverage || true && node scripts/fix-coverage-paths.cjs && node scripts/generate-badge.cjs",
-    "version:show": "node -e \"console.log(require('./package.json').version)\"",
-    "docs": "typedoc"
+    "test:coverage": "jest --config jest.config.coverage.cjs --coverage",
+    "docs": "typedoc",
+    "docs:generate": "npm run docs && npm run docs:generate:coverage && npm run docs:fix:coverage && npm run docs:generate:badge && npm run docs:fix:escape",
+    "docs:generate:coverage": "npm run test:coverage || exit 0",
+    "docs:fix:coverage": "node scripts/fix-coverage-paths.cjs",
+    "docs:generate:badge": "node scripts/generate-badge.cjs",
+    "docs:fix:escape": "node scripts/replace-doc-escaping.cjs",
+    "version:show": "node -e \"console.log(require('./package.json').version)\""
   },
   "repository": {
     "type": "git",

--- a/scripts/replace-doc-escaping.cjs
+++ b/scripts/replace-doc-escaping.cjs
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const docsDir = path.join(__dirname, '..', '.locale', 'docs');
+
+const getAllFiles = (dir, files = []) => {
+    fs.readdirSync(dir).forEach(file => {
+        const fullPath = path.join(dir, file);
+        if (fs.statSync(fullPath).isDirectory()) {
+            getAllFiles(fullPath, files);
+        } else {
+            files.push(fullPath);
+        }
+    });
+    return files;
+};
+
+// Alle HTML-Dateien im docs-Ordner finden
+const htmlFiles = getAllFiles(docsDir).filter(file => file.endsWith('.html'));
+
+// Alle HTML-Dateien bearbeiten
+htmlFiles.forEach(filePath => {
+    fs.readFile(filePath, 'utf8', (err, data) => {
+        if (err) {
+            console.error(`Error reading file ${filePath}:`, err);
+            return;
+        }
+
+        // `\@` durch `@` ersetzen
+        let fixedData = data.replace(/\\@/g, '@');
+
+        fs.writeFile(filePath, fixedData, 'utf8', (err) => {
+            if (err) {
+                console.error(`Error writing file ${filePath}:`, err);
+                return;
+            }
+
+            console.log(`Fixed escaping in ${filePath}`);
+        });
+
+    });
+});


### PR DESCRIPTION
Updated ESLint rules to turn off 'no-console' to allow console statements. Streamlined the GitHub Actions workflow to combine test coverage and TypeDoc generation into a single script for more efficient documentation deployment. Enhanced README with simplified test coverage badges. Added new npm scripts to automate documentation fixes, including a script to correct escaping issues in HTML files. Improved documentation generation, ensuring comprehensive and accurate project documentation.