### PR TITLE
Update decorators for stable TypeScript API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat: Add new `IdentifierRequiredError` class for missing identifiers.
+- feat: Add the option to use the decorators without passing the identifier: In this case, the identifier will be the class name (register) or the property name (inject).
 
 ### Deprecated
 
 
 ### Removed
 
+- feat!: Disable `experimentalDecorators` and `emitDecoratorMetadata` in the `tsconfig.json` file to reflect the change to the stable decorators api.
 
 ### Fixed
 
+- feat!: Update `Register`, `RegisterInstance` and `Inject` decorators to reflect the change to the stable decorators api.
+- feat!: Update `Inject` Decorator typing to reflect the correct property type.
 
 ### Security
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-injex",
-  "version": "0.0.9",
+  "version": "0.1.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-injex",
-      "version": "0.0.9",
+      "version": "0.1.0-alpha",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-prettier": "^5.2.1",
@@ -5957,6 +5957,11 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-injex",
-  "version": "0.1.0-.1",
+  "version": "0.1.0-alpha",
   "description": "Simple boilerplate code free dependency injection system for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-injex",
-  "version": "0.1.0",
+  "version": "0.1.0-.1",
   "description": "Simple boilerplate code free dependency injection system for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/__tests__/Decorators.spec.ts
+++ b/src/__tests__/Decorators.spec.ts
@@ -1,9 +1,9 @@
 /* istanbul ignore file */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Inject } from 'src/decorators/Inject';
-import { DependencyResolutionError } from 'src/interfaces/Exceptions';
-import { ForceConstructor } from 'src/types/GenericContructor';
+import { DependencyResolutionError } from '../interfaces/Exceptions';
 import { ITSinjex_, ITSinjex } from '../interfaces/ITSinjex';
+import { ForceConstructor } from '../types/GenericContructor';
 
 /**
  * Test the Inject decorator.

--- a/src/__tests__/Decorators.spec.ts
+++ b/src/__tests__/Decorators.spec.ts
@@ -67,6 +67,29 @@ export function test_InjectDecorator(
             expect(instance.getDependency().value).toBe('test-value-init');
         });
 
+        it('should inject dependency and run initializer without identifier', () => {
+            container.register('MockDependencyIdentifier', {
+                value: 'test-value',
+            });
+
+            class TestClass {
+                @Inject(undefined, (x: string) => {
+                    (x as unknown as { value: string }).value =
+                        'test-value-init';
+
+                    return x;
+                })
+                MockDependencyIdentifier!: any;
+
+                public getDependency() {
+                    return this.MockDependencyIdentifier;
+                }
+            }
+
+            const instance = new TestClass();
+            expect(instance.getDependency().value).toBe('test-value-init');
+        });
+
         it('should throw an error when necessary is true and the initializer throws an error', () => {
             let _error: Error | undefined = undefined;
 
@@ -78,7 +101,7 @@ export function test_InjectDecorator(
                 class TestClass {
                     @Inject(
                         'InitThrowDependencie',
-                        () => {
+                        (): any => {
                             throw new Error('Initializer error');
                         },
                         true,
@@ -275,6 +298,19 @@ export function test_RegisterDecorator(
                 TestClass,
             );
         });
+
+        it('should register a dependency without an identifier', () => {
+            @register()
+            class TestClass {
+                private readonly _dependency!: any;
+
+                public getDependency() {
+                    return this._dependency;
+                }
+            }
+
+            expect(container.resolve('TestClass')).toBe(TestClass);
+        });
     });
 }
 
@@ -309,6 +345,23 @@ export function test_RegisterInstanceDecorator(
             expect(
                 container.resolve<TestClass>('InstanceIdentifier').mark,
             ).toBe('instance');
+        });
+
+        it('should register an instance of a dependency with an identifier', () => {
+            @registerInstance()
+            class TestClass {
+                private readonly _dependency!: any;
+
+                public getDependency() {
+                    return this._dependency;
+                }
+
+                public mark: string = 'instance';
+            }
+
+            expect(container.resolve<TestClass>('TestClass').mark).toBe(
+                'instance',
+            );
         });
 
         it('should register an instance of a dependency an run the init function', () => {

--- a/src/decorators/Inject.ts
+++ b/src/decorators/Inject.ts
@@ -1,11 +1,11 @@
+import { TSinjex } from '../classes/TSinjex';
 import {
     DependencyResolutionError,
     IdentifierRequiredError,
     InitializationError,
     InjectorError,
     NoInstantiationMethodError,
-} from 'src/interfaces/Exceptions';
-import { TSinjex } from '../classes/TSinjex';
+} from '../interfaces/Exceptions';
 import { Identifier } from '../types/Identifier';
 import { InitDelegate } from '../types/InitDelegate';
 

--- a/src/decorators/Inject.ts
+++ b/src/decorators/Inject.ts
@@ -52,7 +52,7 @@ export function Inject<TargetType, DependencyType, PropertyType>(
     ): (
         this: TargetType,
         initialValue: PropertyType | undefined,
-    ) => PropertyType | undefined {
+    ) => PropertyType {
         const _identifier = identifier ?? context.name;
 
         if (_identifier == null && necessary === true)
@@ -73,7 +73,7 @@ export function Inject<TargetType, DependencyType, PropertyType>(
         return function (
             this: TargetType,
             initialValue: PropertyType | undefined,
-        ): PropertyType | undefined {
+        ): PropertyType {
             let instance: DependencyType | PropertyType | undefined;
 
             const dependency: DependencyType | undefined = tryAndCatch(

--- a/src/decorators/Inject.ts
+++ b/src/decorators/Inject.ts
@@ -48,9 +48,7 @@ export function Inject<TargetType, DependencyType, PropertyType>(
 ) {
     return function (
         constructor: undefined,
-        context: ClassFieldDecoratorContext<TargetType> & {
-            name: PropertyType;
-        },
+        context: ClassFieldDecoratorContext<TargetType>,
     ): void {
         const _identifier = identifier ?? context.name;
 

--- a/src/decorators/Register.ts
+++ b/src/decorators/Register.ts
@@ -1,14 +1,14 @@
+import { IdentifierRequiredError } from 'src/interfaces/Exceptions';
 import { TSinjex } from '../classes/TSinjex';
 import { Identifier } from '../types/Identifier';
 
 /**
  * A decorator to register a class in the **TSinjex** DI (Dependency Injection) container.
  * @template TargetType The type of the class to be registered.
- * @param identifier The identifier used to register the class in the DI container.
- * @see {@link Identifier} for more information on identifiers.
- * @param deprecated If true, the dependency is deprecated and a warning
- * is logged only once upon the first resolution of the dependency.
+ * @param identifier The {@link Identifier|identifier} used to register the class in the DI container or the class name if not provided.
+ * @param deprecated If true, the dependency is deprecated and a warning is logged only once upon the first resolution of the dependency.
  * @returns The decorator function to be applied on the class.
+ * @throws An {@link IdentifierRequiredError} if the identifier is not provided and the class name is not available.
  * @example
  * ```ts
  * \@Register('MyClassIdentifier')
@@ -19,12 +19,16 @@ import { Identifier } from '../types/Identifier';
  */
 export function Register<
     TargetType extends new (...args: unknown[]) => InstanceType<TargetType>,
->(identifier: Identifier, deprecated?: boolean) {
-    return function (constructor: TargetType, ...args: unknown[]): void {
-        // Get the instance of the DI container
-        const diContainer = TSinjex.getInstance();
+>(identifier?: Identifier, deprecated?: boolean) {
+    return function (
+        constructor: TargetType,
+        context: ClassDecoratorContext<TargetType>,
+    ) {
+        const _identifier = identifier ?? context.name;
 
-        // Register the class in the DI container
-        diContainer.register(identifier, constructor, deprecated);
+        if (_identifier == null) throw new IdentifierRequiredError();
+
+        const diContainer = TSinjex.getInstance();
+        diContainer.register(_identifier, constructor, deprecated);
     };
 }

--- a/src/decorators/Register.ts
+++ b/src/decorators/Register.ts
@@ -1,5 +1,5 @@
-import { IdentifierRequiredError } from 'src/interfaces/Exceptions';
 import { TSinjex } from '../classes/TSinjex';
+import { IdentifierRequiredError } from '../interfaces/Exceptions';
 import { Identifier } from '../types/Identifier';
 
 /**

--- a/src/decorators/RegisterInstance.ts
+++ b/src/decorators/RegisterInstance.ts
@@ -1,5 +1,5 @@
-import { IdentifierRequiredError } from 'src/interfaces/Exceptions';
 import { TSinjex } from '../classes/TSinjex';
+import { IdentifierRequiredError } from '../interfaces/Exceptions';
 import { Identifier } from '../types/Identifier';
 import { InitDelegate } from '../types/InitDelegate';
 

--- a/src/decorators/RegisterInstance.ts
+++ b/src/decorators/RegisterInstance.ts
@@ -1,3 +1,4 @@
+import { IdentifierRequiredError } from 'src/interfaces/Exceptions';
 import { TSinjex } from '../classes/TSinjex';
 import { Identifier } from '../types/Identifier';
 import { InitDelegate } from '../types/InitDelegate';
@@ -5,12 +6,11 @@ import { InitDelegate } from '../types/InitDelegate';
 /**
  * A decorator to register an instance of a class in the DI (Dependency Injection) container.
  * @template TargetType The type of the class whose instance is to be registered.
- * @param identifier The identifier used to register the instance in the DI container.
- * @see {@link Identifier} for more information on identifiers.
- * @param init An optional initializer function which get the constructor of the class
+ * @param identifier The {@link Identifier|identifier} used to register the class in the DI container or the class name if not provided.
+ * @param init An optional initializer {@link InitDelegate|function} which get the constructor of the class
  * as input and returns an instance of the class.
- * @see {@link InitDelegate} for more information on initializer functions.
  * @returns The decorator function to be applied on the class.
+ * @throws An {@link IdentifierRequiredError} if the identifier is not provided and the class name is not available.
  * @example
  * ```ts
  * \@RegisterInstance('MyClassInstanceIdentifier', (constructor) => new constructor())
@@ -22,43 +22,51 @@ import { InitDelegate } from '../types/InitDelegate';
 export function RegisterInstance<
     TargetType extends new (..._args: unknown[]) => InstanceType<TargetType>,
 >(
-    identifier: Identifier,
+    identifier?: Identifier,
     init?: InitDelegate<
         TargetType & { new (..._args: unknown[]): InstanceType<TargetType> },
         InstanceType<TargetType>
     >,
 ) {
-    return function (constructor: TargetType, ...args: unknown[]): void {
-        // Get the instance of the DI container
+    return function (
+        constructor: TargetType,
+        context: ClassDecoratorContext<TargetType>,
+    ): void {
+        const _identifier = identifier ?? context.name;
+
+        if (_identifier == null) throw new IdentifierRequiredError();
+
         const diContainer = TSinjex.getInstance();
         let instance: InstanceType<TargetType>;
 
+        /**
+         * Get the instance of the class
+         * and replace the lazy proxy with the instance
+         * for performance optimization.
+         */
+        const getAndRegisterInstance = (): void => {
+            if (instance == null) {
+                if (init) {
+                    instance = init(constructor);
+                } else {
+                    instance = new constructor();
+                }
+            }
+            diContainer.register(_identifier, instance);
+        };
+
         // Create a proxy to instantiate the class when needed (Lazy Initialization)
-        let lazyProxy: unknown = new Proxy(
+        const lazyProxy: unknown = new Proxy(
             {},
             {
-                get(target, prop, receiver) {
-                    if (instance == null) {
-                        if (init) {
-                            instance = init(constructor);
-                        } else {
-                            instance = new constructor(...args);
-                        }
-                    }
-                    lazyProxy = instance;
+                get(_target, prop, _receiver) {
+                    getAndRegisterInstance();
 
                     // Return the requested property of the instance
                     return instance[prop as keyof InstanceType<TargetType>];
                 },
-                set(target, prop, value, receiver) {
-                    if (instance == null) {
-                        if (init) {
-                            instance = init(constructor);
-                        } else {
-                            instance = new constructor(...args);
-                        }
-                    }
-                    lazyProxy = instance;
+                set(_target, prop, value, _receiver) {
+                    getAndRegisterInstance();
 
                     // Set the requested property of the instance
                     return (instance[prop as keyof InstanceType<TargetType>] =
@@ -67,7 +75,6 @@ export function RegisterInstance<
             },
         );
 
-        // Register the lazy proxy in the DI container
-        diContainer.register(identifier, lazyProxy);
+        diContainer.register(_identifier, lazyProxy);
     };
 }

--- a/src/interfaces/Exceptions.ts
+++ b/src/interfaces/Exceptions.ts
@@ -16,6 +16,19 @@ export class TSinjexError extends Error {
 }
 
 /**
+ * Error class for missing identifiers in {@link ITSinjex} methods.
+ */
+export class IdentifierRequiredError extends TSinjexError {
+    /**
+     * Creates a new instance of {@link IdentifierRequiredError}
+     */
+    constructor() {
+        super('Identifier is required.');
+        this.name = 'TSinjexIdentifierRequiredError';
+    }
+}
+
+/**
  * Error class for dependency resolution errors in {@link ITSinjex}.
  * @see {@link ITSinjex.resolve}
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,6 @@
         "importHelpers": true,
         "isolatedModules": true,
         "resolveJsonModule": true,
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
         "lib": [


### PR DESCRIPTION
- **Added**
  - `IdentifierRequiredError` class for missing identifiers.
  - Option to use decorators without passing an identifier; defaults to class name (register) or property name (inject).

- **Removed**
  - `experimentalDecorators` and `emitDecoratorMetadata` settings from `tsconfig.json`.

- **Fixed**
  - Updated `Register`, `RegisterInstance`, and `Inject` decorators to reflect the stable decorators API.
  - Corrected `Inject` decorator typing for accurate property type.