### PR TITLE
Add pre-release build option and streamline deployment

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - 'dev/*'
         paths:
             - 'package.json'
     workflow_dispatch: # Allows manual execution of the workflow.
@@ -22,14 +23,8 @@ jobs:
               with:
                   node-version: '20.8.0'
 
-            - name: Install Dependencies
-              run: npm install
-
-            - name: Run Tests
-              run: npm run test:verbose
-
-            - name: Build the Project
-              run: npm run build:tsc
+            - name: Install dependencies, run tests and build
+              run: npm run prepare:deploy
 
             - name: Get the version
               id: get_version
@@ -77,8 +72,9 @@ jobs:
                   echo "Generating release notes from ${{ env.PREVIOUS_TAG }} to HEAD..."
                   repo_url=$(git config --get remote.origin.url)
                   notes=$(git log ${{ env.PREVIOUS_TAG }}..HEAD --pretty=format:"- [\`%h\`]($repo_url/commit/%H): %s%n")
-                  echo "Release notes:"
+                  echo "See [CHANGELOG.md](./CHANGELOG.md) for more details."
                   echo "$notes"
+                  echo ""
                   echo "### Changes in this release" > release_notes.md
                   echo "$notes" >> release_notes.md
               shell: bash
@@ -90,17 +86,6 @@ jobs:
                   git config --local user.email "actions@github.com"
               shell: bash
 
-            # - name: Create temporary branch
-            #   id: create_temp_branch
-            #   if: steps.check_version.outputs.skip_release == 'false'
-            #   run: |
-            #       git checkout --orphan release/v${{ env.VERSION }}
-            #       git reset
-            #       rm -f .gitignore
-            #       git add README.md package.json LICENSE dist/ src/ tsconfig.json
-            #       git commit -m "Prepare files for release ${{ env.VERSION }}"
-            #   shell: bash
-
             - name: Create and push tag
               id: create_tag
               if: steps.check_version.outputs.skip_release == 'false'
@@ -111,6 +96,15 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
 
+            - name: Set Release Prerelease Flag
+              id: set_prerelease_flag
+              run: |
+                  if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+                    echo "PRE_RELEASE=false" >> $GITHUB_ENV
+                  elif [[ "${{ github.ref }}" == refs/heads/dev/* ]]; then
+                    echo "PRE_RELEASE=true" >> $GITHUB_ENV
+                  fi
+
             - name: Release
               if: steps.check_version.outputs.skip_release == 'false'
               uses: softprops/action-gh-release@v2
@@ -118,6 +112,6 @@ jobs:
                   tag_name: ${{ env.VERSION }}
                   name: Release ${{ env.VERSION }}
                   body_path: release_notes.md
-                  prerelease: true
+                  prerelease: ${{ env.PRE_RELEASE }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add pre release building to release workflow on dev/* branches an version changes.
+
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "docs:fix:coverage": "node scripts/fix-coverage-paths.cjs",
     "docs:generate:badge": "node scripts/generate-badge.cjs",
     "docs:fix:escape": "node scripts/replace-doc-escaping.cjs",
-    "version:show": "node -e \"console.log(require('./package.json').version)\""
+    "version:show": "node -e \"console.log(require('./package.json').version)\"",
+    "prepare:deploy": "npm install && npm run test:verbose && npm run build:tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Modifications
- Added support for pre-release builds from `dev/*` branches
- Consolidated install, test, and build commands into a single `prepare:deploy` script
- Updated release note generation to reference `CHANGELOG.md` for details
- Introduced logic to set the release pre-release flag based on branch

### Description
This pull request makes several updates to the GitHub Actions workflow and `package.json`:

1. **Workflow Changes:**
   - **Branch Support:** Added support for triggering the release workflow on pushes to `dev/*` branches.
   - **Command Consolidation:** Combined the installation of dependencies, running tests, and building the project into a single command `npm run prepare:deploy`.
   - **Release Notes:** Updated the release note generation step to point to `CHANGELOG.md` for detailed changes.
   - **Pre-release Flag:** Added a step to set the pre-release flag based on whether the build is from the `main` branch or a `dev/*` branch.

2. **Package.json Update:**
   - Added a new script `prepare:deploy` which runs `npm install`, `npm run test:verbose`, and `npm run build:tsc`.

These updates streamline the release process and ensure that builds from development branches are marked as pre-releases.